### PR TITLE
fix: rename `target-id` to `target`

### DIFF
--- a/pkg/cli/lint.go
+++ b/pkg/cli/lint.go
@@ -33,7 +33,7 @@ func (lc *lintCommand) command() *cli.Command {
 				Aliases: []string{"o"},
 			},
 			&cli.StringFlag{
-				Name:    "target-id",
+				Name:    "target",
 				Aliases: []string{"t"},
 			},
 			&cli.StringFlag{
@@ -89,7 +89,7 @@ func (lc *lintCommand) action(c *cli.Context) error {
 		ErrorLevel:      c.String("error-level"),
 		ShownErrorLevel: c.String("shown-error-level"),
 		ConfigFilePath:  c.String("config"),
-		TargetID:        c.String("target-id"),
+		TargetID:        c.String("target"),
 		OutputSuccess:   c.Bool("output-success"),
 		Output:          c.String("output"),
 		RootDir:         rootDir,

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -29,7 +29,7 @@ func (tc *testCommand) command() *cli.Command {
 		Action: tc.action,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:    "target-id",
+				Name:    "target",
 				Aliases: []string{"t"},
 			},
 		},
@@ -70,7 +70,7 @@ func (tc *testCommand) action(c *cli.Context) error {
 	return ctrl.Test(c.Context, logE, &testcmd.ParamTest{ //nolint:wrapcheck
 		FilePaths:      c.Args().Slice(),
 		ConfigFilePath: c.String("config"),
-		TargetID:       c.String("target-id"),
+		TargetID:       c.String("target"),
 		RootDir:        rootDir,
 		DataRootDir:    dataRootDir,
 		PWD:            pwd,


### PR DESCRIPTION
BREAKING CHANGE: the command line option `target-id` is renamed to `target`