### PR TITLE
fix: merge modules to lint_files

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -84,16 +84,14 @@ func TestRawConfig_Parse(t *testing.T) { //nolint:funlen
 									"limit": 10,
 								},
 							},
-						},
-						Modules: []*config.RawModule{
 							{
-								Glob: "github_archive/github.com/suzuki-shunsuke/example-lintnet-modules/foo/*.jsonnet@0ed62adf055a4fbd7ef7ebe304f01794508ed325:v0.1.3",
+								Glob: "module:github_archive/github.com/suzuki-shunsuke/example-lintnet-modules/foo/*.jsonnet@0ed62adf055a4fbd7ef7ebe304f01794508ed325:v0.1.3",
 								Config: map[string]any{
 									"excluded": []string{"test"},
 								},
 							},
 							{
-								Glob: "github_archive/github.com/suzuki-shunsuke/example-lintnet-modules/bar/*.jsonnet@0ed62adf055a4fbd7ef7ebe304f01794508ed325:v0.1.3",
+								Glob: "module:github_archive/github.com/suzuki-shunsuke/example-lintnet-modules/bar/*.jsonnet@0ed62adf055a4fbd7ef7ebe304f01794508ed325:v0.1.3",
 							},
 						},
 						DataFiles: []string{

--- a/pkg/config/lint_file.go
+++ b/pkg/config/lint_file.go
@@ -14,9 +14,10 @@ type LintFile struct {
 
 type LintGlob struct {
 	// Glob is either an absolute path or a relative path from configuration file path
-	Glob     string         `json:"path"`
-	Config   map[string]any `json:"config,omitempty"`
-	Excluded bool           `json:"-"`
+	Glob     string          `json:"path"`
+	Files    []*LintGlobFile `json:"files,omitempty"`
+	Config   map[string]any  `json:"config,omitempty"`
+	Excluded bool            `json:"-"`
 }
 
 func (lg *LintGlob) UnmarshalJSON(b []byte) error {
@@ -26,6 +27,7 @@ func (lg *LintGlob) UnmarshalJSON(b []byte) error {
 	}
 	lg.Config = rm.Config
 	lg.Glob = rm.Glob
+	lg.Files = rm.Files
 	return nil
 }
 


### PR DESCRIPTION
## ⚠️ Breaking Changes

`modules` is merged to `lint_files`.
If you use modules, you have to set the prefix `module:`.

e.g.

```
'module:github_archive/github.com/lintnet/modules@d69d0083dcb2696dd3427c484f36940f717a9285:v0.1.2'
```