### PR TITLE
fix: fix a bug that jsonschema.Validate can't find JSON Schema if lintnet is executed on a different directory

### DIFF
--- a/pkg/jsonnet/json_schema.go
+++ b/pkg/jsonnet/json_schema.go
@@ -17,7 +17,7 @@ func ValidateJSONSchema(name string) *jsonnet.NativeFunction {
 		Func: func(s []any) (any, error) {
 			schema, err := json.Marshal(s[0])
 			if err != nil {
-				return "marshal a JSON Schema as JSON: " + err.Error(), nil
+				return "marshal a JSON Schema as JSON: " + err.Error(), nil //nolint:nilerr
 			}
 			sch, err := jsonschema.CompileString("", string(schema))
 			if err != nil {

--- a/pkg/jsonnet/json_schema.go
+++ b/pkg/jsonnet/json_schema.go
@@ -15,11 +15,11 @@ func ValidateJSONSchema(name string) *jsonnet.NativeFunction {
 		Name:   name,
 		Params: ast.Identifiers{"schema", "v"},
 		Func: func(s []any) (any, error) {
-			schemaS, ok := s[0].(string)
-			if !ok {
-				return "the first argument must be a string", nil
+			schema, err := json.Marshal(s[0])
+			if err != nil {
+				return "marshal a JSON Schema as JSON: " + err.Error(), nil
 			}
-			sch, err := jsonschema.Compile(schemaS)
+			sch, err := jsonschema.CompileString("", string(schema))
 			if err != nil {
 				return "compile a JSON Schema: " + err.Error(), nil //nolint:nilerr
 			}


### PR DESCRIPTION
## ⚠️ Breaking Changes

The signature of `jsonschema.Validate` is changed.