### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -5,12 +5,14 @@ permissions: {}
 jobs:
   autofix:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write
     timeout-minutes: 15
     steps:
-      - uses: suzuki-shunsuke/go-autofix-action@ba716cebb7767055bdde0e62bb91d715bde39ab2 # v0.1.12
+      - uses: suzuki-shunsuke/go-autofix-action@9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e # v0.1.13
         with:
           aqua_version: v2.59.1
+          takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
 
       - run: pinact -v
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,9 @@ on:
 permissions: {}
 jobs:
   release:
-    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@b2ecf54e35aca9e9689e761f5bd6d1ad9542a8cf # v8.0.0
+    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     with:
       go-version-file: go.mod
       aqua_version: v2.59.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,10 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write

--- a/.github/workflows/wc-integration-test.yaml
+++ b/.github/workflows/wc-integration-test.yaml
@@ -1,11 +1,17 @@
 ---
 name: integration-test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   integration-test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -13,5 +19,10 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - run: go install ./cmd/lintnet
       - run: lintnet lint

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,20 +1,31 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
       golangci-lint-timeout: 120s
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write
 
   integration-test:
     uses: ./.github/workflows/wc-integration-test.yaml
-    permissions: {}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+    permissions:
+      contents: read
+      id-token: write
 
   test_doc:
     uses: ./.github/workflows/workflow_call_deploy_doc.yaml


### PR DESCRIPTION
## Overview

Introduce [Takumi Guard](https://github.com/suzuki-shunsuke/ghalint) (Go variant) into the CI workflows, following the same pattern rolled out across the suzuki-shunsuke repositories.

## Changes

### `.github/workflows/release.yaml`
- Bump `go-release-workflow` v8.0.0 → v8.1.0
- Pass `secrets.TAKUMI_GUARD_BOT_ID`

### `.github/workflows/workflow_call_test.yaml`
- Declare `on.workflow_call.secrets.TAKUMI_GUARD_BOT_ID` (`required: true`)
- `test` job: bump `go-test-full-workflow` v5.0.2 → v6.0.0, pass the secret, add `id-token: write`
- `integration-test` job: pass the secret and grant `contents: read` + `id-token: write` (the nested reusable workflow requests these, so the calling job must grant them)

### `.github/workflows/test.yaml`
- `test` job: pass `secrets.TAKUMI_GUARD_BOT_ID` and add `id-token: write`

### `.github/workflows/wc-integration-test.yaml`
- Declare `on.workflow_call.secrets.TAKUMI_GUARD_BOT_ID` (`required: true`)
- Add `contents: read` / `id-token: write` to the `integration-test` job
- Add a `flatt-security/setup-takumi-guard-golang@v1` step right after `setup-go`, before `go install`, so Takumi Guard is set up before any Go module download

### `.github/workflows/autofix.yaml`
- Bump `go-autofix-action` v0.1.12 → v0.1.13
- Add the `takumi_guard_bot_id` input and `id-token: write` permission

The npm/docusaurus deploy-doc workflows (`test_doc` / `workflow_call_deploy_doc.yaml`) are out of scope and left unchanged.

## Note

- `go-test-full-workflow` crosses a **major** version (v5 → v6); please review the CI run for any breaking changes.
- The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)