### PR TITLE
ci(security): use takumi guard for npm

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -27,6 +27,18 @@ jobs:
           node-version-file: website/.nvmrc
           cache: npm
           cache-dependency-path: website/package-lock.json
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+      - name: Move the npmrc to the user npmrc
+        # setup-takumi-guard-npm writes the registry and auth token to ./.npmrc,
+        # but npm ci runs in website/ and npm does not read parent directories'
+        # .npmrc. Move it to the user-level ~/.npmrc so npm ci picks it up.
+        run: |
+          if [ -f .npmrc ]; then
+            cat .npmrc >> "$HOME/.npmrc"
+            rm .npmrc
+          fi
       - run: npm ci
         working-directory: website
       - run: bash scripts/generate-usage.sh

--- a/.github/workflows/workflow_call_deploy_doc.yaml
+++ b/.github/workflows/workflow_call_deploy_doc.yaml
@@ -1,5 +1,9 @@
 name: Deploy document (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   deploy_doc:
     timeout-minutes: 15
@@ -7,7 +11,21 @@ jobs:
     permissions:
       contents: write
       issues: write
+      id-token: write
     steps:
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+      - name: Move the npmrc to the user npmrc
+        # setup-takumi-guard-npm writes the registry and auth token to ./.npmrc,
+        # but release-doc-action runs its own actions/checkout (clean) and npm ci
+        # in website/, which would not read this .npmrc. Move it to the
+        # user-level ~/.npmrc so it survives the checkout and npm ci picks it up.
+        run: |
+          if [ -f .npmrc ]; then
+            cat .npmrc >> "$HOME/.npmrc"
+            rm .npmrc
+          fi
       - uses: suzuki-shunsuke/release-doc-action@a9e1ea0c4ca8c62906ca2a7fd3fa33325ee43ec9 # v0.1.0
         with:
           source_dir: website

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -29,6 +29,9 @@ jobs:
 
   test_doc:
     uses: ./.github/workflows/workflow_call_deploy_doc.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       issues: write
+      id-token: write


### PR DESCRIPTION
## Overview

Extend [Takumi Guard](https://github.com/suzuki-shunsuke/ghalint) to the **npm** package installs in CI, complementing the Go-side takumi guard added earlier. This routes `npm ci` through the Takumi Guard proxy registry via `flatt-security/setup-takumi-guard-npm`.

## Background

`setup-takumi-guard-npm` writes the registry and auth token to a project-level `.npmrc` in the workspace root, but `npm ci` runs in `website/` (npm does not read parent directories' `.npmrc`). Since this repo has no committed `website/.npmrc`, the generated `.npmrc` is moved to the user-level `$HOME/.npmrc`, which `npm ci` reads from any directory. (This mirrors the approach used in github-comment's deploy-doc job.)

## Changes

### `.github/workflows/autofix.yaml`
- After `setup-node` and before `npm ci`: add `flatt-security/setup-takumi-guard-npm@v1.1.1` (`bot-id`) and a step moving the generated `.npmrc` to `$HOME/.npmrc`.
- The job already has `id-token: write` (added in the Go PR), required for the action's OIDC token exchange. The secret is available directly (entrypoint workflow).

### `.github/workflows/workflow_call_deploy_doc.yaml`
- Declare `on.workflow_call.secrets.TAKUMI_GUARD_BOT_ID` (`required: true`).
- Add `id-token: write` to the `deploy_doc` job.
- Add `setup-takumi-guard-npm` + move-to-`$HOME/.npmrc` before `release-doc-action` (which runs its own checkout and `npm ci`).

### `.github/workflows/workflow_call_test.yaml`
- `test_doc` job (caller of deploy-doc): pass `secrets.TAKUMI_GUARD_BOT_ID` and add `id-token: write`.

## Note

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)