### PR TITLE
fix(website): override uuid to fix a Dependabot alert

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -17787,13 +17787,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/website/package.json
+++ b/website/package.json
@@ -23,7 +23,8 @@
     "react-dom": "^19.0.0"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.2",


### PR DESCRIPTION
## Check List

- [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

Fix the Dependabot alert for uuid 8.3.2 (GHSA-w5hq-g745-h8pq) on `website/package-lock.json` by pinning uuid to 11.1.1 with an npm `override`.

uuid is a transitive dependency of `@docusaurus/core > webpack-dev-server > sockjs`, so Renovate can't update it. sockjs calls `require('uuid').v4`, and uuid v11 still ships a CJS entry point exporting `v4`, so the override is safe. It is only used by the dev server anyway.

`npm run build` passes.

The two `image-size` alerts are left as they are: 2.0.2 is the newest published version and both advisories are still unpatched.